### PR TITLE
Type-Erased Node References

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "camino"
@@ -655,18 +655,19 @@ checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "leptos"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5046c590aea121f6ad5e71fcb75453a933425d39527b9a3b1b295235afc8df"
+checksum = "5c4e32cac886183e0faf8dd30944072302359a8508380827f649ef9bbdd179ad"
 dependencies = [
  "any_spawner",
  "cfg-if",
@@ -733,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_config"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2d64c43e2554108c26da3127f8384d92ca76c6f0b7288d1c09c8cc68152064"
+checksum = "1961b08a7dc3f4a559223be87c44b56bb565bf0b438909a0c3c31d88bfad0982"
 dependencies = [
  "config",
  "regex",
@@ -746,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_dom"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c15aca81dc2edd040b51c46734f65c6f36e6ba8a31347c1354c94b958044ae0"
+checksum = "652ba5e3a5c4e703e5bd4b24b62de9dbeedca84e5f31aff045bf329014418496"
 dependencies = [
  "js-sys",
  "or_poisoned",
@@ -761,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_hot_reload"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445f3a62696d2d66bef288911af34405718880b4b8dd6c5cfb7751fd8ffcc6b"
+checksum = "77bc67823a8eb1c961ee08dd7b3a814964c63928a64954e3521733b56dd7e66f"
 dependencies = [
  "anyhow",
  "camino",
@@ -779,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_macro"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f690c955274f1722ee6c66463ace79301d53a8c2bf7f6e4e61b978ca239e20"
+checksum = "0d4b2418deac01fe9a3862d410a6a6beff235e4b124d9e874986bb22617aeea6"
 dependencies = [
  "attribute-derive",
  "cfg-if",
@@ -801,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_server"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93450589df3b3e398c7f5ea64d8f1c8369b1ba9b90e1f70f6cb996b8d443ca3e"
+checksum = "5cc1e6a182eebf8b1739dff377e63688eb7ab08c133f657e939969daa356a275"
 dependencies = [
  "any_spawner",
  "base64",
@@ -1326,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033cb8014aa86a7ce0c6ee58d23dce1a078b2e320dc6c53bb439663993199b1f"
+checksum = "1abb4001047ecff14681ec411bbd9a8a95a7b405e543ed043fece8f0c5a2f4fe"
 dependencies = [
  "bytes",
  "const_format",
@@ -1356,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0249e8a55ca464a1e69f02a95d562f2c65e92e301093a02ebf15d21f68f2a99e"
+checksum = "7883cf3cb2522ce663df033e2fd3093a4497e9b8ed30f354200ef7058c9c792c"
 dependencies = [
  "const_format",
  "convert_case",
@@ -1370,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro_default"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c54a6d43cd0f3d2bdf0c85b6119f378b6b89d528159af9cde77f229faeecbc"
+checksum = "a734ef90a83ee9517468b38a017f602a869b382c18e8e8b4118f3f1b88f2856c"
 dependencies = [
  "server_fn_macro",
  "syn",
@@ -1667,9 +1668,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1678,13 +1679,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1693,21 +1693,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1715,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1728,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-streams"
@@ -1747,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "leptos-node-ref"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "leptos",
  "send_wrapper",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "leptos-struct-component"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "leptos",
  "leptos-node-ref",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "leptos-struct-component-macro"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "leptos-style"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "indexmap",
  "leptos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,7 @@ repository = "https://github.com/RustForWeb/leptos-utils"
 version = "0.0.4"
 
 [workspace.dependencies]
-leptos = "0.7.0"
+leptos = "0.7.2"
+leptos-struct-component-macro = { path = "./packages/leptos-struct-component-macro" }
+leptos-node-ref = { path = "./packages/leptos-node-ref" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Rust For Web <info@rustforweb.org>"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/RustForWeb/leptos-utils"
-version = "0.0.3"
+version = "0.0.4"
 
 [workspace.dependencies]
 leptos = "0.7.0"

--- a/packages/leptos-node-ref/src/any_node_ref.rs
+++ b/packages/leptos-node-ref/src/any_node_ref.rs
@@ -18,11 +18,6 @@ impl AnyNodeRef {
     pub fn new() -> Self {
         Self(RwSignal::new(None))
     }
-
-    /// Attempts to cast the `AnyNodeRef` to a specific element type.
-    pub fn cast<E: JsCast + Clone>(&self) -> Option<E> {
-        self.0.get()?.dyn_ref::<E>().cloned()
-    }
 }
 
 impl Default for AnyNodeRef {

--- a/packages/leptos-node-ref/src/any_node_ref.rs
+++ b/packages/leptos-node-ref/src/any_node_ref.rs
@@ -1,5 +1,4 @@
 use leptos::{
-    wasm_bindgen::JsCast,
     prelude::{
         guards::{Derefable, ReadGuard},
         DefinedAt, ReadUntracked, RwSignal, Get, Set, Track, NodeRef

--- a/packages/leptos-node-ref/tests/node_ref.rs
+++ b/packages/leptos-node-ref/tests/node_ref.rs
@@ -1,0 +1,29 @@
+use leptos_node_ref::{AnyNodeRef, ToAnyNodeRef};
+use leptos::{prelude::*, html};
+
+#[test]
+fn test_any_node_ref_creation() {
+    let node_ref = AnyNodeRef::new();
+    assert!(node_ref.get().is_none(), "New AnyNodeRef should be empty");
+}
+
+#[test]
+fn test_to_any_node_ref() {
+    let div_ref: NodeRef<html::Div> = NodeRef::new();
+    let any_ref = div_ref.to_any();
+    assert!(any_ref.get().is_none(), "Converted AnyNodeRef should be initially empty");
+}
+
+#[test]
+fn test_clone_and_copy() {
+    let node_ref = AnyNodeRef::new();
+    let cloned_ref = node_ref;
+    let _copied_ref = cloned_ref; // Should be copyable
+    assert!(cloned_ref.get().is_none(), "Cloned AnyNodeRef should be empty");
+}
+
+#[test]
+fn test_default() {
+    let node_ref = AnyNodeRef::default();
+    assert!(node_ref.get().is_none(), "Default AnyNodeRef should be empty");
+}

--- a/packages/leptos-struct-component/Cargo.toml
+++ b/packages/leptos-struct-component/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 
 [dependencies]
 leptos.workspace = true
-leptos-struct-component-macro = { path = "../leptos-struct-component-macro", version = "0.0.3" }
+leptos-struct-component-macro.workspace = true
 
 [dev-dependencies]
-leptos-node-ref = { path = "../leptos-node-ref" }
+leptos-node-ref.workspace = true


### PR DESCRIPTION
### What's Changed
- Added `AnyNodeRef` for type-erased node references
- Introduced `ToAnyNodeRef` trait for converting between typed and untyped node refs
- Implemented conversion for HTML, SVG, and Math node types
- Also reorganized the workspace & shared versioning

### Why
Enables more flexible handling of DOM node references across different element types. Specifically It's needed for updating this implementation https://github.com/RustForWeb/radix/issues/26 for `0.7.X`

### Examples

```rust
let div_ref: NodeRef<html::Div> = NodeRef::new();
let any_ref = div_ref.to_any(); // Type-erased conversion
```

Working towards:
```rust
pub fn compose_refs(refs: impl IntoIterator<Item = AnyNodeRef>) -> AnyNodeRef {
    let composed_ref = AnyNodeRef::new();
    let refs: Vec<_> = refs.into_iter().collect();
    // ...
}
```

### My Checklist
- [x] Added new functionality
- [x] Updated tests
- [x] Ran all tests
- [x] Maintained existing behavior

Would you like me to modify this further @DanielleHuisman?