### PR TITLE
Add `MaybeCallback`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "leptos-maybe-callback"
+version = "0.0.3"
+dependencies = [
+ "leptos",
+ "log",
+]
+
+[[package]]
 name = "leptos-node-ref"
 version = "0.0.3"
 dependencies = [
@@ -867,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "manyhow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ version = "0.0.3"
 
 [workspace.dependencies]
 leptos = "0.7.0"
+log = "0.4.25"

--- a/packages/leptos-maybe-callback/Cargo.toml
+++ b/packages/leptos-maybe-callback/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "leptos-maybe-callback"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+leptos.workspace = true

--- a/packages/leptos-maybe-callback/Cargo.toml
+++ b/packages/leptos-maybe-callback/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "leptos-maybe-callback"
+description = "Zero-cost, type-safe optional callbacks for Leptos with flexible event handling"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/packages/leptos-maybe-callback/Cargo.toml
+++ b/packages/leptos-maybe-callback/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "leptos-maybe-callback"
-description = "Zero-cost, type-safe optional callbacks for Leptos with flexible event handling"
+description = "Optional callbacks for Leptos."
+
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -9,3 +10,6 @@ version.workspace = true
 
 [dependencies]
 leptos.workspace = true
+
+[dev-dependencies]
+log.workspace = true

--- a/packages/leptos-maybe-callback/README.md
+++ b/packages/leptos-maybe-callback/README.md
@@ -1,0 +1,144 @@
+# Leptos Maybe Callback
+
+Lightweight, type-safe optional callbacks for [Leptos](https://leptos.dev/). Provides a zero-cost abstraction for
+conditionally handling event callbacks in your Leptos components.
+
+## Features
+
+- **Optional Callbacks**: Represent callbacks that may or may not exist.
+- **Zero-Cost Abstraction**: Minimal overhead using Rust's `Option` and enums.
+- **Seamless Integration**: Works effortlessly with Leptos signals and components.
+- **Flexible Conversions**: Convert from various callback-like types, including nested `Option`s and `Fn` closures.
+- **Thread-Safe & Wasm-Ready**: Implements `Send + Sync` where applicable.
+- **Convenient Handler Generation**: Utilize `as_handler` and `into_handler` methods for generating event handlers.
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+leptos-maybe-callback = "0.4.0"
+```
+
+## Usage Examples
+
+### Component with Optional Callback Prop
+
+Define a component that accepts an optional callback using `#[prop(into, optional)]`. This allows passing a closure, a
+`Callback`, or omitting the prop.
+
+```rust
+use leptos::prelude::*;
+use leptos_maybe_callback::MaybeCallback;
+
+/// A button component with an optional `onclick` callback.
+#[component]
+#[allow(non_snake_case)]
+pub fn Button(
+    #[prop(into, optional)]
+    onclick: MaybeCallback<MouseEvent>,
+) -> impl IntoView {
+    view! {
+        <button on:click=onclick.into_handler()>
+            "Click me"
+        </button>
+    }
+}
+```
+
+### Using the Component with a Closure
+
+Use the `Button` component and provide a closure for the `onclick` prop.
+
+```rust
+use leptos::prelude::*;
+use leptos_maybe_callback::MaybeCallback;
+
+/// Parent component using `Button` with a closure.
+#[component]
+#[allow(non_snake_case)]
+pub fn ButtonWithClosure() -> impl IntoView {
+    view! {
+        <div>
+            <Button onclick=|_| log::info!("Clicked via closure!") />
+            <Button />
+        </div>
+    }
+}
+```
+
+### Using the Component with a `Callback`
+
+Alternatively, pass a `Callback` as the `onclick` prop.
+
+```rust
+use leptos::prelude::*;
+use leptos_maybe_callback::MaybeCallback;
+
+/// Parent component using `Button` with a `Callback`.
+#[component]
+#[allow(non_snake_case)]
+pub fn ButtonWithCallback() -> impl IntoView {
+    let on_click = Callback::new(|event: MouseEvent| {
+        log::info!("Clicked with event: {:?}", event);
+    });
+
+    view! {
+        <div>
+            <Button onclick=on_click />
+            <Button />
+        </div>
+    }
+}
+```
+
+### Omitting the Callback
+
+If no callback is needed, omit the `onclick` prop or pass `None`.
+
+```rust
+use leptos::prelude::*;
+use leptos_maybe_callback::MaybeCallback;
+
+/// Parent component using `Button` without a callback.
+#[component]
+#[allow(non_snake_case)]
+pub fn ButtonWithoutCallback() -> impl IntoView {
+    view! {
+        <div>
+            <Button />
+            <Button onclick=None />
+        </div>
+    }
+}
+```
+
+## Documentation
+
+Comprehensive (WIP + TBD) documentation is available on [docs.rs](https://docs.rs/leptos-maybe-callback).
+
+## Testing
+
+Run the test suite with:
+
+```bash
+cargo test
+```
+
+## Contributing
+
+Contributions are welcome! Please submit pull requests or open issues
+on [GitHub](https://github.com/RustForWeb/leptos-maybe-callback).
+
+## Credits
+
+The initial idea and implementation of `MaybeCallback` were contributed
+by [@israelbarbara](https://github.com/israelbarbara) on Discord (
+26/12/2024). [@geoffreygarrett](https://github.com/geoffreygarrett) facilitated its integration into
+the [RustForWeb](https://github.com/RustForWeb) project.
+
+## Rust For Web
+
+Part of the [Rust For Web](https://github.com/RustForWeb) initiative to create and port web UI libraries for Rust. All
+projects are free and open source.

--- a/packages/leptos-maybe-callback/README.md
+++ b/packages/leptos-maybe-callback/README.md
@@ -129,7 +129,7 @@ cargo test
 ## Contributing
 
 Contributions are welcome! Please submit pull requests or open issues
-on [GitHub](https://github.com/RustForWeb/leptos-maybe-callback).
+on [GitHub](https://github.com/RustForWeb/leptos-utils).
 
 ## Credits
 

--- a/packages/leptos-maybe-callback/README.md
+++ b/packages/leptos-maybe-callback/README.md
@@ -1,27 +1,14 @@
 # Leptos Maybe Callback
 
-Lightweight, type-safe optional callbacks for [Leptos](https://leptos.dev/). Provides a zero-cost abstraction for
-conditionally handling event callbacks in your Leptos components.
+Optional callbacks for [Leptos](https://leptos.dev/).
 
-## Features
+## Documentation
 
-- **Optional Callbacks**: Represent callbacks that may or may not exist.
-- **Zero-Cost Abstraction**: Minimal overhead using Rust's `Option` and enums.
-- **Seamless Integration**: Works effortlessly with Leptos signals and components.
-- **Flexible Conversions**: Convert from various callback-like types, including nested `Option`s and `Fn` closures.
-- **Thread-Safe & Wasm-Ready**: Implements `Send + Sync` where applicable.
-- **Convenient Handler Generation**: Utilize `as_handler` and `into_handler` methods for generating event handlers.
+Documentation for the crate is available on [Docs.rs](https://docs.rs/):
 
-## Installation
+-   [`leptos-node-ref`](https://docs.rs/leptos-maybe-callback/latest/leptos_maybe_callback/)
 
-Add to your `Cargo.toml`:
-
-```toml
-[dependencies]
-leptos-maybe-callback = "0.4.0"
-```
-
-## Usage Examples
+## Example
 
 ### Component with Optional Callback Prop
 
@@ -29,12 +16,11 @@ Define a component that accepts an optional callback using `#[prop(into, optiona
 `Callback`, or omitting the prop.
 
 ```rust
-use leptos::prelude::*;
+use leptos::{ev::MouseEvent, prelude::*};
 use leptos_maybe_callback::MaybeCallback;
 
 /// A button component with an optional `onclick` callback.
 #[component]
-#[allow(non_snake_case)]
 pub fn Button(
     #[prop(into, optional)]
     onclick: MaybeCallback<MouseEvent>,
@@ -57,7 +43,6 @@ use leptos_maybe_callback::MaybeCallback;
 
 /// Parent component using `Button` with a closure.
 #[component]
-#[allow(non_snake_case)]
 pub fn ButtonWithClosure() -> impl IntoView {
     view! {
         <div>
@@ -73,12 +58,11 @@ pub fn ButtonWithClosure() -> impl IntoView {
 Alternatively, pass a `Callback` as the `onclick` prop.
 
 ```rust
-use leptos::prelude::*;
+use leptos::{ev::MouseEvent, prelude::*};
 use leptos_maybe_callback::MaybeCallback;
 
 /// Parent component using `Button` with a `Callback`.
 #[component]
-#[allow(non_snake_case)]
 pub fn ButtonWithCallback() -> impl IntoView {
     let on_click = Callback::new(|event: MouseEvent| {
         log::info!("Clicked with event: {:?}", event);
@@ -98,47 +82,23 @@ pub fn ButtonWithCallback() -> impl IntoView {
 If no callback is needed, omit the `onclick` prop or pass `None`.
 
 ```rust
-use leptos::prelude::*;
+use leptos::{ev::MouseEvent, prelude::*};
 use leptos_maybe_callback::MaybeCallback;
 
 /// Parent component using `Button` without a callback.
 #[component]
-#[allow(non_snake_case)]
 pub fn ButtonWithoutCallback() -> impl IntoView {
     view! {
         <div>
             <Button />
-            <Button onclick=None />
+            <Button onclick={None::<Callback<MouseEvent>>} />
         </div>
     }
 }
 ```
 
-## Documentation
-
-Comprehensive (WIP + TBD) documentation is available on [docs.rs](https://docs.rs/leptos-maybe-callback).
-
-## Testing
-
-Run the test suite with:
-
-```bash
-cargo test
-```
-
-## Contributing
-
-Contributions are welcome! Please submit pull requests or open issues
-on [GitHub](https://github.com/RustForWeb/leptos-utils).
-
-## Credits
-
-The initial idea and implementation of `MaybeCallback` were contributed
-by [@israelbarbara](https://github.com/israelbarbara) on Discord (
-26/12/2024). [@geoffreygarrett](https://github.com/geoffreygarrett) facilitated its integration into
-the [RustForWeb](https://github.com/RustForWeb) project.
-
 ## Rust For Web
 
-Part of the [Rust For Web](https://github.com/RustForWeb) initiative to create and port web UI libraries for Rust. All
-projects are free and open source.
+The Leptos Maybe Callback project is part of [Rust For Web](https://github.com/RustForWeb).
+
+[Rust For Web](https://github.com/RustForWeb) creates and ports web UI libraries for Rust. All projects are free and open source.

--- a/packages/leptos-maybe-callback/src/lib.rs
+++ b/packages/leptos-maybe-callback/src/lib.rs
@@ -1,0 +1,5 @@
+//! [`MaybeCallback`] extras for [Leptos](https://leptos.dev/).
+//!
+mod maybe_callback;
+
+pub use maybe_callback::*;

--- a/packages/leptos-maybe-callback/src/lib.rs
+++ b/packages/leptos-maybe-callback/src/lib.rs
@@ -1,5 +1,131 @@
-//! [`MaybeCallback`] extras for [Leptos](https://leptos.dev/).
+//! Optional callbacks for [Leptos](https://leptos.dev/).
 //!
+//! # Example
+//!
+//! ## Component with Optional Callback Prop
+//!
+//! Define a component that accepts an optional callback using `#[prop(into, optional)]`. This allows passing a closure, a
+//! `Callback`, or omitting the prop.
+//!
+//! ```
+//! use leptos::{ev::MouseEvent, prelude::*};
+//! use leptos_maybe_callback::MaybeCallback;
+//!
+//! /// A button component with an optional `onclick` callback.
+//! #[component]
+//! pub fn Button(
+//!     #[prop(into, optional)]
+//!     onclick: MaybeCallback<MouseEvent>,
+//! ) -> impl IntoView {
+//!     view! {
+//!         <button on:click=onclick.into_handler()>
+//!             "Click me"
+//!         </button>
+//!     }
+//! }
+//! ```
+//!
+//! ## Using the Component with a Closure
+//!
+//! Use the `Button` component and provide a closure for the `onclick` prop.
+//!
+//! ```
+//! # use leptos::ev::MouseEvent;
+//! use leptos::prelude::*;
+//! use leptos_maybe_callback::MaybeCallback;
+//!
+//! # #[component]
+//! # pub fn Button(
+//! #     #[prop(into, optional)]
+//! #     onclick: MaybeCallback<MouseEvent>,
+//! # ) -> impl IntoView {
+//! #     view! {
+//! #         <button on:click=onclick.into_handler()>
+//! #             "Click me"
+//! #         </button>
+//! #     }
+//! # }
+//! #
+//! /// Parent component using `Button` with a closure.
+//! #[component]
+//! pub fn ButtonWithClosure() -> impl IntoView {
+//!     view! {
+//!         <div>
+//!             <Button onclick=|_| log::info!("Clicked via closure!") />
+//!             <Button />
+//!         </div>
+//!     }
+//! }
+//! ```
+//!
+//! ## Using the Component with a `Callback`
+//!
+//! Alternatively, pass a `Callback` as the `onclick` prop.
+//!
+//! ```rust
+//! use leptos::{ev::MouseEvent, prelude::*};
+//! use leptos_maybe_callback::MaybeCallback;
+//!
+//! # #[component]
+//! # pub fn Button(
+//! #     #[prop(into, optional)]
+//! #     onclick: MaybeCallback<MouseEvent>,
+//! # ) -> impl IntoView {
+//! #     view! {
+//! #         <button on:click=onclick.into_handler()>
+//! #             "Click me"
+//! #         </button>
+//! #     }
+//! # }
+//! #
+//! /// Parent component using `Button` with a `Callback`.
+//! #[component]
+//! pub fn ButtonWithCallback() -> impl IntoView {
+//!     let on_click = Callback::new(|event: MouseEvent| {
+//!         log::info!("Clicked with event: {:?}", event);
+//!     });
+//!
+//!     view! {
+//!         <div>
+//!             <Button onclick=on_click />
+//!             <Button />
+//!         </div>
+//!     }
+//! }
+//! ```
+//!
+//! ## Omitting the Callback
+//!
+//! If no callback is needed, omit the `onclick` prop or pass `None`.
+//!
+//! ```rust
+//! use leptos::{ev::MouseEvent, prelude::*};
+//! use leptos_maybe_callback::MaybeCallback;
+//!
+//! # #[component]
+//! # pub fn Button(
+//! #     #[prop(into, optional)]
+//! #     onclick: MaybeCallback<MouseEvent>,
+//! # ) -> impl IntoView {
+//! #     view! {
+//! #         <button on:click=onclick.into_handler()>
+//! #             "Click me"
+//! #         </button>
+//! #     }
+//! # }
+//! #
+//! /// Parent component using `Button` without a callback.
+//! #[component]
+//! pub fn ButtonWithoutCallback() -> impl IntoView {
+//!     view! {
+//!         <div>
+//!             <Button />
+//!             <Button onclick={None::<Callback<MouseEvent>>} />
+//!         </div>
+//!     }
+//! }
+//! ```
+
 mod maybe_callback;
 
 pub use maybe_callback::*;

--- a/packages/leptos-maybe-callback/src/maybe_callback.rs
+++ b/packages/leptos-maybe-callback/src/maybe_callback.rs
@@ -1,0 +1,189 @@
+use std::ops::Deref;
+use leptos::prelude::{Callback, Callable};
+
+/// A wrapper around an optional callback that provides convenient conversion
+/// and method call semantics. This type implements `From` for various callback-like
+/// types including `Fn` traits and nested `Option`s.
+#[derive(Debug, Clone)]
+pub struct MaybeCallback<T: 'static>(pub Option<Callback<T>>);
+
+impl<T> Deref for MaybeCallback<T> {
+    type Target = Option<Callback<T>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> MaybeCallback<T> {
+    /// Creates a new `MaybeCallback` from a callback.
+    pub fn new(callback: impl Into<Callback<T>>) -> Self {
+        Self(Some(callback.into()))
+    }
+
+    /// Returns a reference to the contained callback, if any.
+    pub fn as_ref(&self) -> Option<&Callback<T>> {
+        self.0.as_ref()
+    }
+
+    /// Runs the stored callback if available.
+    pub fn run(&self, event: T) {
+        if let Some(ref cb) = self.0 {
+            cb.run(event);
+        }
+    }
+
+    /// Converts this `MaybeCallback<T>` into a `MaybeCallback<U>` by applying `f`.
+    pub fn map<U: 'static>(
+        self,
+        f: impl FnOnce(Callback<T>) -> Callback<U>,
+    ) -> MaybeCallback<U> {
+        MaybeCallback(self.0.map(f))
+    }
+
+    /// Returns `true` if the callback is `Some`.
+    pub fn is_some(&self) -> bool {
+        self.0.is_some()
+    }
+
+    /// Returns `true` if the callback is `None`.
+    pub fn is_none(&self) -> bool {
+        self.0.is_none()
+    }
+
+    /// Converts `MaybeCallback<T>` into a `Callback<T>` that conditionally runs the inner callback.
+    pub fn as_callback(&self) -> Callback<T> {
+        // Clone the inner `Option<Callback<T>>` to own it within the closure.
+        let callback = self.0.clone();
+        Callback::new(move |event: T| {
+            if let Some(ref cb) = callback {
+                cb.run(event);
+            }
+        })
+    }
+
+    /// Consumes `MaybeCallback<T>` and returns a `FnMut(T)` closure that runs the callback if present.
+    pub fn into_handler(self) -> impl FnMut(T) {
+        move |event: T| {
+            self.run(event);
+        }
+    }
+
+    /// Borrows `MaybeCallback<T>` and returns a `FnMut(T)` closure that runs the callback if present.
+    /// This method clones the inner callback to avoid consuming `self`.
+    pub fn as_handler(&self) -> impl FnMut(T) + '_ {
+        let callback = self.0.clone();
+        move |event: T| {
+            if let Some(ref cb) = callback {
+                cb.run(event);
+            }
+        }
+    }
+}
+
+// Implement `From` for various callback-like types.
+
+// From `MaybeCallback<T>` to `Option<Callback<T>>`
+impl<T> From<MaybeCallback<T>> for Option<Callback<T>> {
+    fn from(maybe: MaybeCallback<T>) -> Self {
+        maybe.0
+    }
+}
+
+// From `Callback<T>` to `MaybeCallback<T>`
+impl<T> From<Callback<T>> for MaybeCallback<T> {
+    fn from(callback: Callback<T>) -> Self {
+        Self(Some(callback))
+    }
+}
+
+// From `Option<Callback<T>>` to `MaybeCallback<T>`
+impl<T> From<Option<Callback<T>>> for MaybeCallback<T> {
+    fn from(option: Option<Callback<T>>) -> Self {
+        Self(option)
+    }
+}
+
+// From `Option<Option<Callback<T>>>` to `MaybeCallback<T>`
+impl<T> From<Option<Option<Callback<T>>>> for MaybeCallback<T> {
+    fn from(opt: Option<Option<Callback<T>>>) -> Self {
+        Self(opt.flatten())
+    }
+}
+
+// From a closure `F` to `MaybeCallback<T>`
+impl<T, F> From<F> for MaybeCallback<T>
+where
+    T: 'static,
+    F: Fn(T) + Send + Sync + 'static,
+{
+    fn from(f: F) -> Self {
+        Self(Some(Callback::new(f)))
+    }
+}
+
+// From `Option<F>` to `MaybeCallback<T>`
+impl<T, F> From<Option<F>> for MaybeCallback<T>
+where
+    T: 'static,
+    F: Fn(T) + Send + Sync + 'static,
+{
+    fn from(opt: Option<F>) -> Self {
+        Self(opt.map(Callback::new))
+    }
+}
+
+// From `Option<Option<F>>` to `MaybeCallback<T>`
+impl<T, F> From<Option<Option<F>>> for MaybeCallback<T>
+where
+    T: 'static,
+    F: Fn(T) + Send + Sync + 'static,
+{
+    fn from(opt: Option<Option<F>>) -> Self {
+        Self(opt.flatten().map(Callback::new))
+    }
+}
+
+impl<T> Default for MaybeCallback<T> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+/// Returns a `FnMut(T)` that runs the callback if present.
+#[deprecated(
+    since = "0.5.0",
+    note = "Use `MaybeCallback::into_handler` method instead."
+)]
+pub fn generate_handler<T>(callback: impl Into<MaybeCallback<T>>) -> impl FnMut(T)
+where
+    T: 'static,
+{
+    let maybe_callback = callback.into();
+    move |event: T| {
+        maybe_callback.run(event);
+    }
+}
+
+/// Builds a handler from a [`MaybeCallback`].
+#[deprecated(
+    since = "0.5.0",
+    note = "Use `MaybeCallback::into_handler` method instead."
+)]
+pub struct Handler;
+
+#[deprecated(
+    since = "0.5.0",
+    note = "Use `MaybeCallback::into_handler` method instead."
+)]
+impl Handler {
+    /// Returns a `FnMut(T)` that runs the callback if present.
+    pub fn from<T>(callback: MaybeCallback<T>) -> impl FnMut(T)
+    where
+        T: 'static,
+    {
+        move |event: T| {
+            callback.run(event);
+        }
+    }
+}

--- a/packages/leptos-maybe-callback/tests/maybe_callback.rs
+++ b/packages/leptos-maybe-callback/tests/maybe_callback.rs
@@ -1,0 +1,246 @@
+use leptos::prelude::{Callback, Callable};
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::Arc;
+use leptos_maybe_callback::*;
+
+/// Tests the default value of `MaybeCallback`, expecting it to be `None`.
+#[test]
+fn test_default() {
+    let maybe_callback: MaybeCallback<()> = Default::default();
+    assert!(maybe_callback.is_none(), "Expected MaybeCallback to be None by default.");
+}
+
+/// Tests creating a `MaybeCallback` from a `Some(Callback)`, expecting it to contain `Some`.
+#[test]
+fn test_from_some_callback() {
+    let was_called = Arc::new(AtomicBool::new(false));
+    let was_called_clone = Arc::clone(&was_called);
+
+    let cb = Callback::new(move |_: bool| {
+        was_called_clone.store(true, Ordering::SeqCst);
+    });
+
+    let maybe = MaybeCallback::from(Some(cb));
+    assert!(maybe.is_some(), "Expected MaybeCallback to be Some.");
+
+    // Execute the callback to ensure it works
+    maybe.run(true);
+    assert!(was_called.load(Ordering::SeqCst), "Callback was not called.");
+}
+
+/// Tests creating a `MaybeCallback` from `None`, expecting it to be `None`.
+#[test]
+fn test_from_none_callback() {
+    let maybe: MaybeCallback<()> = MaybeCallback::from(None::<Callback<()>>);
+    assert!(maybe.is_none(), "Expected MaybeCallback to be None when initialized with None.");
+}
+
+/// Tests the `run` method when `MaybeCallback` contains `Some(Callback)`.
+#[test]
+fn test_run_some() {
+    let counter = Arc::new(AtomicI32::new(0));
+    let counter_clone = Arc::clone(&counter);
+
+    let cb = Callback::new(move |val: i32| {
+        counter_clone.fetch_add(val, Ordering::SeqCst);
+    });
+
+    let maybe = MaybeCallback::from(Some(cb));
+    maybe.run(5);
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        5,
+        "Counter should have been incremented by 5."
+    );
+}
+
+/// Tests the `run` method when `MaybeCallback` is `None`, ensuring no action is taken.
+#[test]
+fn test_run_none() {
+    let counter = Arc::new(AtomicI32::new(0));
+    let maybe: MaybeCallback<i32> = MaybeCallback::from(None::<Callback<i32>>);
+    maybe.run(5);
+    // Should remain unchanged
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        0,
+        "Counter should remain unchanged when MaybeCallback is None."
+    );
+}
+
+/// Tests the `map` method on a `MaybeCallback` containing `Some(Callback)`.
+#[test]
+fn test_map_some() {
+    let was_called = Arc::new(AtomicBool::new(false));
+    let was_called_clone = Arc::clone(&was_called);
+
+    let original_cb = Callback::new(move |val: i32| {
+        assert_eq!(val, 42, "Callback received incorrect value.");
+        was_called_clone.store(true, Ordering::SeqCst);
+    });
+
+    let maybe = MaybeCallback::from(Some(original_cb));
+
+    // Map i32 -> &str
+    let new_maybe = maybe.map(|cb| Callback::new(move |_: &str| {
+        cb.run(42); // calls original callback
+    }));
+
+    assert!(new_maybe.is_some(), "Mapped MaybeCallback should be Some.");
+
+    // Execute the mapped callback
+    new_maybe.run("Hello");
+    assert!(
+        was_called.load(Ordering::SeqCst),
+        "Mapped callback was not called."
+    );
+}
+
+/// Tests the `map` method on a `MaybeCallback` that is `None`, ensuring it remains `None`.
+#[test]
+fn test_map_none() {
+    let maybe: MaybeCallback<i32> = MaybeCallback::from(None::<Callback<i32>>);
+    let new_maybe = maybe.map(|_cb| {
+        // This closure should never be called
+        Callback::new(|val: &str| println!("val: {}", val))
+    });
+    assert!(
+        new_maybe.is_none(),
+        "Mapped MaybeCallback should remain None when original is None."
+    );
+}
+
+/// Tests the `as_handler` method by generating multiple handlers and ensuring they work independently.
+#[test]
+fn test_as_handler_multiple() {
+    let counter1 = Arc::new(AtomicI32::new(0));
+    let counter1_clone = Arc::clone(&counter1);
+
+    let counter2 = Arc::new(AtomicI32::new(0));
+    let counter2_clone = Arc::clone(&counter2);
+
+    let cb = Callback::new(move |val: i32| {
+        counter1_clone.fetch_add(val, Ordering::SeqCst);
+    });
+
+    let maybe = MaybeCallback::from(Some(cb));
+    let mut handler1 = maybe.as_handler();
+
+    // Create another handler with a different callback
+    let cb2 = Callback::new(move |val: i32| {
+        counter2_clone.fetch_add(val, Ordering::SeqCst);
+    });
+    let maybe2 = MaybeCallback::from(Some(cb2));
+    let mut handler2 = maybe2.as_handler();
+
+    handler1(10);
+    handler2(20);
+
+    assert_eq!(
+        counter1.load(Ordering::SeqCst),
+        10,
+        "First handler should have incremented counter1 by 10."
+    );
+    assert_eq!(
+        counter2.load(Ordering::SeqCst),
+        20,
+        "Second handler should have incremented counter2 by 20."
+    );
+}
+
+/// Tests the `as_callback` method to ensure it returns a `Callback` that conditionally executes.
+#[test]
+fn test_as_callback_some() {
+    let was_called = Arc::new(AtomicBool::new(false));
+    let was_called_clone = Arc::clone(&was_called);
+
+    let cb = Callback::new(move |_| {
+        was_called_clone.store(true, Ordering::SeqCst);
+    });
+
+    let maybe = MaybeCallback::from(Some(cb));
+    let callback = maybe.as_callback();
+    callback.run(());
+
+    assert!(
+        was_called.load(Ordering::SeqCst),
+        "Callback should have been executed."
+    );
+}
+
+/// Tests the `as_callback` method when `MaybeCallback` is `None`, ensuring it does nothing.
+#[test]
+fn test_as_callback_none() {
+    let maybe: MaybeCallback<()> = MaybeCallback::from(None::<Callback<()>>);
+    let callback = maybe.as_callback();
+    // Should not panic or do anything
+    callback.run(());
+}
+
+/// Tests the `into_handler` method by consuming the `MaybeCallback` and ensuring it cannot be used afterward.
+#[test]
+fn test_into_handler() {
+    let counter = Arc::new(AtomicI32::new(0));
+    let counter_clone = Arc::clone(&counter);
+
+    let cb = Callback::new(move |val: i32| {
+        counter_clone.fetch_add(val, Ordering::SeqCst);
+    });
+
+    let maybe = MaybeCallback::from(Some(cb));
+    let mut handler = maybe.into_handler();
+    handler(15);
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        15,
+        "Counter should have been incremented by 15."
+    );
+
+    // Since `maybe` is consumed, attempting to use it should result in a compile-time error.
+    // Uncommenting the following lines should cause a compilation error.
+    //
+    // maybe.run(10); // Error: use of moved value: `maybe`
+}
+
+/// Tests the deprecated `generate_handler` function to ensure it still works as expected.
+#[test]
+#[allow(deprecated)]
+fn test_generate_handler() {
+    let counter = Arc::new(AtomicI32::new(0));
+    let counter_clone = Arc::clone(&counter);
+
+    let cb = Callback::new(move |val: i32| {
+        counter_clone.fetch_add(val, Ordering::SeqCst);
+    });
+
+    let mut handler = generate_handler(cb);
+    handler(10);
+    handler(5);
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        15,
+        "Counter should have been incremented by 15 using generate_handler."
+    );
+}
+
+/// Tests the deprecated `Handler::from` method to ensure it still works as expected.
+#[test]
+#[allow(deprecated)]
+fn test_handler_from() {
+    let counter = Arc::new(AtomicI32::new(0));
+    let counter_clone = Arc::clone(&counter);
+
+    let cb = Callback::new(move |val: i32| {
+        counter_clone.fetch_add(val, Ordering::SeqCst);
+    });
+
+    let mut handler_fn = Handler::from(MaybeCallback::from(Some(cb)));
+    handler_fn(7);
+    handler_fn(3);
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        10,
+        "Counter should have been incremented by 10 using Handler::from."
+    );
+}

--- a/packages/leptos-maybe-callback/tests/maybe_callback.rs
+++ b/packages/leptos-maybe-callback/tests/maybe_callback.rs
@@ -1,13 +1,17 @@
-use leptos::prelude::{Callback, Callable};
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::Arc;
+
+use leptos::prelude::{Callable, Callback};
 use leptos_maybe_callback::*;
 
 /// Tests the default value of `MaybeCallback`, expecting it to be `None`.
 #[test]
 fn test_default() {
     let maybe_callback: MaybeCallback<()> = Default::default();
-    assert!(maybe_callback.is_none(), "Expected MaybeCallback to be None by default.");
+    assert!(
+        maybe_callback.is_none(),
+        "Expected MaybeCallback to be None by default."
+    );
 }
 
 /// Tests creating a `MaybeCallback` from a `Some(Callback)`, expecting it to contain `Some`.
@@ -25,14 +29,20 @@ fn test_from_some_callback() {
 
     // Execute the callback to ensure it works
     maybe.run(true);
-    assert!(was_called.load(Ordering::SeqCst), "Callback was not called.");
+    assert!(
+        was_called.load(Ordering::SeqCst),
+        "Callback was not called."
+    );
 }
 
 /// Tests creating a `MaybeCallback` from `None`, expecting it to be `None`.
 #[test]
 fn test_from_none_callback() {
     let maybe: MaybeCallback<()> = MaybeCallback::from(None::<Callback<()>>);
-    assert!(maybe.is_none(), "Expected MaybeCallback to be None when initialized with None.");
+    assert!(
+        maybe.is_none(),
+        "Expected MaybeCallback to be None when initialized with None."
+    );
 }
 
 /// Tests the `run` method when `MaybeCallback` contains `Some(Callback)`.
@@ -82,9 +92,11 @@ fn test_map_some() {
     let maybe = MaybeCallback::from(Some(original_cb));
 
     // Map i32 -> &str
-    let new_maybe = maybe.map(|cb| Callback::new(move |_: &str| {
-        cb.run(42); // calls original callback
-    }));
+    let new_maybe = maybe.map(|cb| {
+        Callback::new(move |_: &str| {
+            cb.run(42); // calls original callback
+        })
+    });
 
     assert!(new_maybe.is_some(), "Mapped MaybeCallback should be Some.");
 
@@ -201,46 +213,4 @@ fn test_into_handler() {
     // Uncommenting the following lines should cause a compilation error.
     //
     // maybe.run(10); // Error: use of moved value: `maybe`
-}
-
-/// Tests the deprecated `generate_handler` function to ensure it still works as expected.
-#[test]
-#[allow(deprecated)]
-fn test_generate_handler() {
-    let counter = Arc::new(AtomicI32::new(0));
-    let counter_clone = Arc::clone(&counter);
-
-    let cb = Callback::new(move |val: i32| {
-        counter_clone.fetch_add(val, Ordering::SeqCst);
-    });
-
-    let mut handler = generate_handler(cb);
-    handler(10);
-    handler(5);
-    assert_eq!(
-        counter.load(Ordering::SeqCst),
-        15,
-        "Counter should have been incremented by 15 using generate_handler."
-    );
-}
-
-/// Tests the deprecated `Handler::from` method to ensure it still works as expected.
-#[test]
-#[allow(deprecated)]
-fn test_handler_from() {
-    let counter = Arc::new(AtomicI32::new(0));
-    let counter_clone = Arc::clone(&counter);
-
-    let cb = Callback::new(move |val: i32| {
-        counter_clone.fetch_add(val, Ordering::SeqCst);
-    });
-
-    let mut handler_fn = Handler::from(MaybeCallback::from(Some(cb)));
-    handler_fn(7);
-    handler_fn(3);
-    assert_eq!(
-        counter.load(Ordering::SeqCst),
-        10,
-        "Counter should have been incremented by 10 using Handler::from."
-    );
 }

--- a/packages/leptos-node-ref/src/lib.rs
+++ b/packages/leptos-node-ref/src/lib.rs
@@ -1,5 +1,5 @@
 //! Node reference extras for [Leptos](https://leptos.dev/).
-//!
+
 mod any_node_ref;
 
 pub use any_node_ref::*;

--- a/packages/leptos-struct-component/src/lib.rs
+++ b/packages/leptos-struct-component/src/lib.rs
@@ -1,4 +1,5 @@
 //! Define [Leptos](https://leptos.dev/) components using structs.
+
 // mod attributes;
 
 pub use leptos_struct_component_macro::*;

--- a/packages/leptos-style/src/lib.rs
+++ b/packages/leptos-style/src/lib.rs
@@ -1,4 +1,5 @@
 //! Style for [Yew](https://yew.rs/) components.
+
 mod style;
 
 pub use crate::style::*;


### PR DESCRIPTION
Adds `MaybeCallback` type for convenient optional callback handling in Leptos components.

Originally proposed by @israelbarbara in [this Discord message](https://discord.com/channels/1275151045378441311/1275159355355959388/1321866261738557470).