### PR TITLE
Add `IntoAttributeValue` implementation for `Style`

### DIFF
--- a/packages/leptos-style/src/style.rs
+++ b/packages/leptos-style/src/style.rs
@@ -94,14 +94,6 @@ impl Display for Style {
     }
 }
 
-impl IntoAttributeValue for Style {
-    type Output = String;
-
-    fn into_attribute_value(self) -> Self::Output {
-        self.to_string()
-    }
-}
-
 impl From<Option<&str>> for Style {
     fn from(value: Option<&str>) -> Style {
         Style(value.map(|value| InnerStyle::String(value.to_string())))
@@ -186,6 +178,14 @@ impl<const N: usize> From<[(String, String); N]> for Style {
         Style(Some(InnerStyle::Structured(IndexMap::from_iter(
             value.map(|(key, value)| (key, Some(value))),
         ))))
+    }
+}
+
+impl IntoAttributeValue for Style {
+    type Output = String;
+
+    fn into_attribute_value(self) -> Self::Output {
+        self.to_string()
     }
 }
 
@@ -343,8 +343,14 @@ mod tests {
 
     #[test]
     fn test_into_attribute_value() {
-        let style = Style::from("color: red; background-color: blue;");
-        let attr_value: String = style.into_attribute_value();
-        assert_eq!(attr_value, "color: red; background-color: blue;");
+        assert_eq!(
+            Style::from("color: red; background-color: blue;").into_attribute_value(),
+            "color: red; background-color: blue;"
+        );
+
+        assert_eq!(
+            Style::from([("color", "red"), ("background-color", "blue")]).into_attribute_value(),
+            "color: red; background-color: blue;"
+        );
     }
 }

--- a/packages/leptos-style/src/style.rs
+++ b/packages/leptos-style/src/style.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use leptos::{ attr::IntoAttributeValue, tachys::html::style::IntoStyle};
+use leptos::{attr::IntoAttributeValue, tachys::html::style::IntoStyle};
 
 fn style_map_to_string(map: &IndexMap<String, Option<String>>) -> String {
     map.iter()
@@ -94,7 +94,6 @@ impl Display for Style {
     }
 }
 
-
 impl IntoAttributeValue for Style {
     type Output = String;
 
@@ -102,7 +101,6 @@ impl IntoAttributeValue for Style {
         self.to_string()
     }
 }
-
 
 impl From<Option<&str>> for Style {
     fn from(value: Option<&str>) -> Style {
@@ -344,9 +342,9 @@ mod tests {
     }
 
     #[test]
-    fn test_into_attribute_value(){
-        let style = Style::from("color: red; background-color: blue;"); 
-        let attr_value: String = style.into_attribute_value(); 
+    fn test_into_attribute_value() {
+        let style = Style::from("color: red; background-color: blue;");
+        let attr_value: String = style.into_attribute_value();
         assert_eq!(attr_value, "color: red; background-color: blue;");
     }
 }

--- a/packages/leptos-style/src/style.rs
+++ b/packages/leptos-style/src/style.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use leptos::tachys::html::style::IntoStyle;
+use leptos::{ attr::IntoAttributeValue, tachys::html::style::IntoStyle};
 
 fn style_map_to_string(map: &IndexMap<String, Option<String>>) -> String {
     map.iter()
@@ -93,6 +93,16 @@ impl Display for Style {
         )
     }
 }
+
+
+impl IntoAttributeValue for Style {
+    type Output = String;
+
+    fn into_attribute_value(self) -> Self::Output {
+        self.to_string()
+    }
+}
+
 
 impl From<Option<&str>> for Style {
     fn from(value: Option<&str>) -> Style {
@@ -331,5 +341,12 @@ mod tests {
             Style::from([("color", None::<String>)]),
             Style::from([("color", None::<String>)]).with_defaults([("color", None::<String>)]),
         );
+    }
+
+    #[test]
+    fn test_into_attribute_value(){
+        let style = Style::from("color: red; background-color: blue;"); 
+        let attr_value: String = style.into_attribute_value(); 
+        assert_eq!(attr_value, "color: red; background-color: blue;");
     }
 }


### PR DESCRIPTION
related to #19

Implementation of IntoAttributeValue trait so its not necessary convert to string using `.to_string()`

